### PR TITLE
99 implement changepoint for categorical data

### DIFF
--- a/tests/test_changepoint_model.py
+++ b/tests/test_changepoint_model.py
@@ -75,7 +75,7 @@ def test_gen_test_array():
          (5, 10, 100), 3, {"switch_components": 2}),
         (AllTastePoissonTrialSwitch, (2, 5, 10, 100),
          3, {"switch_components": 2}),
-    ],
+        (CategoricalChangepoint3D, (5, 10, 100), 3, {}),
 )
 def test_model_initialization(model_class, data_shape, n_states, extra_args):
     """Test that models can be initialized and generate a model."""
@@ -106,7 +106,18 @@ def test_model_initialization(model_class, data_shape, n_states, extra_args):
     assert model is not None
 
 
-# Test the run_all_tests function
+def test_categorical_changepoint_3d():
+    """Test the CategoricalChangepoint3D model."""
+    data = np.random.randint(0, 3, size=(5, 10, 100))
+    model_instance = CategoricalChangepoint3D(data_array=data, n_states=3)
+    model = model_instance.generate_model()
+    with model:
+        inference = pm.ADVI()
+        approx = pm.fit(n=10, method=inference)
+        trace = approx.sample(draws=10)
+    assert model is not None
+    assert "tau" in trace.varnames
+
 @pytest.mark.slow
 def test_run_all_tests():
     """Test that run_all_tests can be imported and executed."""

--- a/tests/test_changepoint_model.py
+++ b/tests/test_changepoint_model.py
@@ -74,7 +74,7 @@ def test_gen_test_array():
         (SingleTastePoissonTrialSwitch, (5, 10, 100), 3, {"switch_components": 2}),
         (AllTastePoissonTrialSwitch, (2, 5, 10, 100), 3, {"switch_components": 2}),
         (CategoricalChangepoint3D, (5, 10, 100), 3, {}),
-    ],
+    ]
 def test_model_initialization(model_class, data_shape, n_states, extra_args):
     """Test that models can be initialized and generate a model."""
     # Generate test data

--- a/tests/test_changepoint_model.py
+++ b/tests/test_changepoint_model.py
@@ -71,11 +71,10 @@ def test_gen_test_array():
         (SingleTastePoissonVarsigFixed, (5, 10, 100), 3, {"inds_span": 1}),
         (AllTastePoisson, (2, 5, 10, 100), 3, {}),
         (AllTastePoissonVarsigFixed, (2, 5, 10, 100), 3, {"inds_span": 1}),
-        (SingleTastePoissonTrialSwitch,
-         (5, 10, 100), 3, {"switch_components": 2}),
+        (SingleTastePoissonTrialSwitch, (5, 10, 100), 3, {"switch_components": 2}),
         (AllTastePoissonTrialSwitch, (2, 5, 10, 100), 3, {"switch_components": 2}),
         (CategoricalChangepoint3D, (5, 10, 100), 3, {}),
-    ]
+    ],
 def test_model_initialization(model_class, data_shape, n_states, extra_args):
     """Test that models can be initialized and generate a model."""
     # Generate test data

--- a/tests/test_changepoint_model.py
+++ b/tests/test_changepoint_model.py
@@ -73,10 +73,9 @@ def test_gen_test_array():
         (AllTastePoissonVarsigFixed, (2, 5, 10, 100), 3, {"inds_span": 1}),
         (SingleTastePoissonTrialSwitch,
          (5, 10, 100), 3, {"switch_components": 2}),
-        (AllTastePoissonTrialSwitch, (2, 5, 10, 100),
-         3, {"switch_components": 2}),
+        (AllTastePoissonTrialSwitch, (2, 5, 10, 100), 3, {"switch_components": 2}),
         (CategoricalChangepoint3D, (5, 10, 100), 3, {}),
-)
+    ]
 def test_model_initialization(model_class, data_shape, n_states, extra_args):
     """Test that models can be initialized and generate a model."""
     # Generate test data


### PR DESCRIPTION
- **feat: implement CategoricalChangepoint3D model for 3D categorical data**
- **fix: correct mismatched parentheses in test parameterization list**
- **fix: close parentheses in pytest parametrize decorator to resolve syntax error**
- **fix: close parentheses in parametrize decorator to resolve syntax error**
