### PR TITLE
ci(github): update Python version and OS for pytest workflow

### DIFF
--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.6.10']
+        python-version: ['3.8.15']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Updated the OS version from Ubuntu 20.04 to Ubuntu 22.04.
- Changed Python version from 3.6.10 to 3.8.15 in the GitHub workflow configuration.