### PR TITLE
Add 1D Poisson changepoint model

### DIFF
--- a/pytau/changepoint_model.py
+++ b/pytau/changepoint_model.py
@@ -49,12 +49,46 @@ def gen_test_array(array_size, n_states, type="poisson"):
     Time will always be last dimension
 
     Args:
-        array_size (tuple): Size of array to generate
+        array_size (tuple or int): Size of array to generate. If int, generates 1D array.
         n_states (int): Number of states to generate
         type (str): Type of data to generate
             - normal
             - poisson
     """
+    # Handle 1D case
+    if isinstance(array_size, int):
+        assert array_size > n_states, "Array too small for states"
+        assert type in [
+            "normal", "poisson"], "Invalid type, please use normal or poisson"
+        
+        # Generate transition times for 1D case
+        transition_times = np.random.random(n_states)
+        transition_times = np.cumsum(transition_times)
+        transition_times = transition_times / transition_times.max()
+        transition_times *= array_size
+        transition_times = transition_times.astype(int)
+        
+        # Generate state bounds
+        state_bounds = np.zeros(n_states + 1, dtype=int)
+        state_bounds[1:] = transition_times
+        state_bounds[-1] = array_size
+        
+        # Generate state rates
+        lambda_vals = np.random.exponential(2.0, n_states) + 0.5
+        
+        # Generate 1D array
+        rate_array = np.zeros(array_size)
+        for i in range(n_states):
+            start_idx = state_bounds[i]
+            end_idx = state_bounds[i + 1]
+            rate_array[start_idx:end_idx] = lambda_vals[i]
+        
+        if type == "poisson":
+            return np.random.poisson(rate_array)
+        else:
+            return np.random.normal(loc=rate_array, scale=0.1)
+    
+    # Handle multi-dimensional case (existing code)
     assert array_size[-1] > n_states, "Array too small for states"
     assert type in [
         "normal", "poisson"], "Invalid type, please use normal or poisson"
@@ -1826,12 +1860,14 @@ def all_taste_poisson_trial_switch(data_array, switch_components, n_states, **kw
 def run_all_tests():
     """Run tests for all model classes"""
     # Create test data
+    test_data_1d = gen_test_array(100, n_states=3, type="poisson")
     test_data_2d = gen_test_array((10, 100), n_states=3, type="normal")
     test_data_3d = gen_test_array((5, 10, 100), n_states=3, type="poisson")
     test_data_4d = gen_test_array((2, 5, 10, 100), n_states=3, type="poisson")
 
     # Test each model class
     models_to_test = [
+        PoissonChangepoint1D(test_data_1d, 3),
         GaussianChangepointMeanVar2D(test_data_2d, 3),
         GaussianChangepointMeanDirichlet(test_data_2d, 5),
         GaussianChangepointMean2D(test_data_2d, 3),
@@ -1858,6 +1894,126 @@ def run_all_tests():
     print("All tests completed")
     if failed_tests:
         print("Failed tests:", failed_tests)
+
+
+############################################################
+# 1D Poisson Changepoint Model
+############################################################
+
+
+class PoissonChangepoint1D(ChangepointModel):
+    """Model for changepoint detection in 1D Poisson time series
+    
+    This model detects changepoints in 1D time series data using a Poisson likelihood.
+    It assumes the data follows a Poisson distribution with different rates in different
+    segments separated by changepoints.
+    """
+
+    def __init__(self, data_array, n_states, **kwargs):
+        """
+        Args:
+            data_array (1D Numpy array): Time series data
+            n_states (int): Number of states to model
+            **kwargs: Additional arguments
+        """
+        super().__init__(**kwargs)
+        self.data_array = np.asarray(data_array)
+        if self.data_array.ndim != 1:
+            raise ValueError("data_array must be 1-dimensional")
+        self.n_states = n_states
+
+    def generate_model(self):
+        """
+        Returns:
+            pymc model: Model class containing graph to run inference on
+        """
+        data_array = self.data_array
+        n_states = self.n_states
+        
+        # Calculate initial lambda values by splitting data into segments
+        mean_vals = np.array([
+            np.mean(x) for x in np.array_split(data_array, n_states)
+        ])
+        mean_vals += 0.01  # To avoid zero starting prob
+        
+        idx = np.arange(len(data_array))
+        length = len(data_array)
+
+        with pm.Model() as model:
+            # Lambda parameters for each state (Poisson rates)
+            lambda_latent = pm.Exponential(
+                "lambda", 1 / mean_vals, shape=n_states
+            )
+
+            # Changepoint locations
+            a_tau = pm.HalfCauchy("a_tau", 3.0, shape=n_states - 1)
+            b_tau = pm.HalfCauchy("b_tau", 3.0, shape=n_states - 1)
+
+            # Initialize changepoints evenly across the time series
+            even_switches = np.linspace(0, 1, n_states + 1)[1:-1]
+            tau_latent = pm.Beta(
+                "tau_latent", 
+                a_tau, 
+                b_tau, 
+                initval=even_switches, 
+                shape=(n_states - 1)
+            ).sort(axis=-1)
+
+            # Convert to actual time indices
+            tau = pm.Deterministic(
+                "tau", idx.min() + (idx.max() - idx.min()) * tau_latent
+            )
+
+            # Create weight matrix for smooth transitions between states
+            weight_stack = tt.math.sigmoid(
+                idx[np.newaxis, :] - tau[:, np.newaxis]
+            )
+            weight_stack = tt.concatenate(
+                [np.ones((1, length)), weight_stack], axis=0
+            )
+            inverse_stack = 1 - weight_stack[1:]
+            inverse_stack = tt.concatenate(
+                [inverse_stack, np.ones((1, length))], axis=0
+            )
+            weight_stack = weight_stack * inverse_stack
+
+            # Calculate time-varying lambda
+            lambda_t = lambda_latent.dot(weight_stack)
+            
+            # Observation model
+            observation = pm.Poisson("obs", lambda_t, observed=data_array)
+
+        return model
+
+    def test(self):
+        """Test the model with synthetic data"""
+        # Generate test data - 1D array with 100 time points
+        test_data = gen_test_array(100, n_states=self.n_states, type="poisson")
+        
+        # Create model with test data
+        test_model = PoissonChangepoint1D(test_data, self.n_states)
+        model = test_model.generate_model()
+
+        # Run a minimal inference to verify model works
+        with model:
+            # Just do a few iterations to test functionality
+            inference = pm.ADVI()
+            approx = pm.fit(n=10, method=inference)
+            trace = approx.sample(draws=10)
+
+        # Check if expected variables are in the trace
+        assert "lambda" in trace.varnames
+        assert "tau" in trace.varnames
+
+        print("Test for PoissonChangepoint1D passed")
+        return True
+
+
+# For backward compatibility
+def poisson_changepoint_1d(data_array, n_states, **kwargs):
+    """Wrapper function for backward compatibility"""
+    model_class = PoissonChangepoint1D(data_array, n_states, **kwargs)
+    return model_class.generate_model()
 
 
 def extract_inferred_values(trace):
@@ -2027,12 +2183,14 @@ def mcmc_fit(model, samples):
 def run_all_tests():
     """Run tests for all model classes"""
     # Create test data
+    test_data_1d = gen_test_array(100, n_states=3, type="poisson")
     test_data_2d = gen_test_array((10, 100), n_states=3, type="normal")
     test_data_3d = gen_test_array((5, 10, 100), n_states=3, type="poisson")
     test_data_4d = gen_test_array((2, 5, 10, 100), n_states=3, type="poisson")
 
     # Test each model class
     models_to_test = [
+        PoissonChangepoint1D(test_data_1d, 3),
         GaussianChangepointMeanVar2D(test_data_2d, 3),
         GaussianChangepointMeanDirichlet(test_data_2d, 5),
         GaussianChangepointMean2D(test_data_2d, 3),
@@ -2059,6 +2217,126 @@ def run_all_tests():
     print("All tests completed")
     if failed_tests:
         print("Failed tests:", failed_tests)
+
+
+############################################################
+# 1D Poisson Changepoint Model
+############################################################
+
+
+class PoissonChangepoint1D(ChangepointModel):
+    """Model for changepoint detection in 1D Poisson time series
+    
+    This model detects changepoints in 1D time series data using a Poisson likelihood.
+    It assumes the data follows a Poisson distribution with different rates in different
+    segments separated by changepoints.
+    """
+
+    def __init__(self, data_array, n_states, **kwargs):
+        """
+        Args:
+            data_array (1D Numpy array): Time series data
+            n_states (int): Number of states to model
+            **kwargs: Additional arguments
+        """
+        super().__init__(**kwargs)
+        self.data_array = np.asarray(data_array)
+        if self.data_array.ndim != 1:
+            raise ValueError("data_array must be 1-dimensional")
+        self.n_states = n_states
+
+    def generate_model(self):
+        """
+        Returns:
+            pymc model: Model class containing graph to run inference on
+        """
+        data_array = self.data_array
+        n_states = self.n_states
+        
+        # Calculate initial lambda values by splitting data into segments
+        mean_vals = np.array([
+            np.mean(x) for x in np.array_split(data_array, n_states)
+        ])
+        mean_vals += 0.01  # To avoid zero starting prob
+        
+        idx = np.arange(len(data_array))
+        length = len(data_array)
+
+        with pm.Model() as model:
+            # Lambda parameters for each state (Poisson rates)
+            lambda_latent = pm.Exponential(
+                "lambda", 1 / mean_vals, shape=n_states
+            )
+
+            # Changepoint locations
+            a_tau = pm.HalfCauchy("a_tau", 3.0, shape=n_states - 1)
+            b_tau = pm.HalfCauchy("b_tau", 3.0, shape=n_states - 1)
+
+            # Initialize changepoints evenly across the time series
+            even_switches = np.linspace(0, 1, n_states + 1)[1:-1]
+            tau_latent = pm.Beta(
+                "tau_latent", 
+                a_tau, 
+                b_tau, 
+                initval=even_switches, 
+                shape=(n_states - 1)
+            ).sort(axis=-1)
+
+            # Convert to actual time indices
+            tau = pm.Deterministic(
+                "tau", idx.min() + (idx.max() - idx.min()) * tau_latent
+            )
+
+            # Create weight matrix for smooth transitions between states
+            weight_stack = tt.math.sigmoid(
+                idx[np.newaxis, :] - tau[:, np.newaxis]
+            )
+            weight_stack = tt.concatenate(
+                [np.ones((1, length)), weight_stack], axis=0
+            )
+            inverse_stack = 1 - weight_stack[1:]
+            inverse_stack = tt.concatenate(
+                [inverse_stack, np.ones((1, length))], axis=0
+            )
+            weight_stack = weight_stack * inverse_stack
+
+            # Calculate time-varying lambda
+            lambda_t = lambda_latent.dot(weight_stack)
+            
+            # Observation model
+            observation = pm.Poisson("obs", lambda_t, observed=data_array)
+
+        return model
+
+    def test(self):
+        """Test the model with synthetic data"""
+        # Generate test data - 1D array with 100 time points
+        test_data = gen_test_array(100, n_states=self.n_states, type="poisson")
+        
+        # Create model with test data
+        test_model = PoissonChangepoint1D(test_data, self.n_states)
+        model = test_model.generate_model()
+
+        # Run a minimal inference to verify model works
+        with model:
+            # Just do a few iterations to test functionality
+            inference = pm.ADVI()
+            approx = pm.fit(n=10, method=inference)
+            trace = approx.sample(draws=10)
+
+        # Check if expected variables are in the trace
+        assert "lambda" in trace.varnames
+        assert "tau" in trace.varnames
+
+        print("Test for PoissonChangepoint1D passed")
+        return True
+
+
+# For backward compatibility
+def poisson_changepoint_1d(data_array, n_states, **kwargs):
+    """Wrapper function for backward compatibility"""
+    model_class = PoissonChangepoint1D(data_array, n_states, **kwargs)
+    return model_class.generate_model()
 
 
 def extract_inferred_values(trace):

--- a/tests/test_changepoint_model.py
+++ b/tests/test_changepoint_model.py
@@ -14,6 +14,7 @@ from pytau.changepoint_model import (
     GaussianChangepointMean2D,
     GaussianChangepointMeanDirichlet,
     GaussianChangepointMeanVar2D,
+    PoissonChangepoint1D,
     SingleTastePoisson,
     SingleTastePoissonDirichlet,
     SingleTastePoissonTrialSwitch,
@@ -168,6 +169,26 @@ def test_advi_fit():
 
     # Skip actual testing as it would require a full PyMC3 model
     pytest.skip("Full testing of advi_fit requires a PyMC3 model")
+
+
+@pytest.mark.slow
+def test_poisson_changepoint_1d():
+    """Test the PoissonChangepoint1D model."""
+    # Generate 1D test data
+    test_data = gen_test_array(100, n_states=3, type="poisson")
+    
+    # Test model creation
+    model_class = PoissonChangepoint1D(test_data, 3)
+    assert model_class.data_array.ndim == 1
+    assert model_class.n_states == 3
+    
+    # Test model generation
+    model = model_class.generate_model()
+    assert model is not None
+    
+    # Test that it raises error for non-1D data
+    with pytest.raises(ValueError):
+        PoissonChangepoint1D(np.random.poisson(2, (10, 100)), 3)
 
 
 def test_module_import():


### PR DESCRIPTION
This PR implements a new 1D Poisson changepoint model to address issue #137.

## Changes Made

- **New Model Class**: Added PoissonChangepoint1D class for detecting changepoints in 1D time series using Poisson likelihood
- **Enhanced Test Data Generation**: Extended gen_test_array function to handle 1D arrays (when array_size is an integer)
- **Comprehensive Testing**: Added tests for the new model including error handling for invalid input dimensions
- **Integration**: Updated test imports and model test suites to include the new model

## Features

- Detects changepoints in 1D time series data using Poisson likelihood
- Supports configurable number of states/segments
- Follows the same API pattern as existing models in the codebase
- Includes proper error handling for invalid input dimensions
- Fully integrated with the existing test framework

## Usage Example

```python
from pytau.changepoint_model import PoissonChangepoint1D, gen_test_array

# Generate test data
data = gen_test_array(100, n_states=3, type='poisson')

# Create and use the model
model = PoissonChangepoint1D(data, n_states=3)
pymc_model = model.generate_model()
```

Fixes #137